### PR TITLE
Better perf for ResultType.Records

### DIFF
--- a/src/DesignTime/InformationSchema.fs
+++ b/src/DesignTime/InformationSchema.fs
@@ -167,11 +167,6 @@ type Column =
 
     member this.ClrType = this.DataType.ClrType
 
-    member this.ClrTypeConsideringNullability = 
-        if this.Nullable
-        then typedefof<_ option>.MakeGenericType this.DataType.ClrType
-        else this.DataType.ClrType
-
     member this.HasDefaultConstraint = string this.DefaultConstraint <> ""
     member this.OptionalForInsert = this.Nullable || this.HasDefaultConstraint || this.AutoIncrement
 

--- a/src/DesignTime/NpgsqlConnectionProvider.fs
+++ b/src/DesignTime/NpgsqlConnectionProvider.fs
@@ -80,7 +80,7 @@ let addCreateCommandMethod(connectionString, rootType: ProvidedTypeDefinition, c
                             Expr.Value resultType
                             Expr.Value collectionType
                             Expr.Value singleRow
-                            QuotationsFactory.BuildResultSetDefinitionsExpr (statements, resultType <> ResultType.DataTable)
+                            QuotationsFactory.BuildDataColumnsExpr (statements, resultType <> ResultType.DataTable)
                             Expr.Value prepare
                         ]))
 

--- a/src/DesignTime/NpgsqlConnectionProvider.fs
+++ b/src/DesignTime/NpgsqlConnectionProvider.fs
@@ -13,7 +13,7 @@ open InformationSchema
 open System.Collections.Concurrent
 
 let methodsCache = ConcurrentDictionary<string, ProvidedMethod> ()
-let typeCache = ConcurrentDictionary<string, ProvidedTypeDefinition> ()
+let typeCache = ConcurrentDictionary<string, ProvidedTypeDefinition * Type> ()
 let schemaCache = ConcurrentDictionary<string, DbSchemaLookups> ()
 
 let addCreateCommandMethod(connectionString, rootType: ProvidedTypeDefinition, commands: ProvidedTypeDefinition, customTypes: Map<string, ProvidedTypeDefinition>,
@@ -198,7 +198,7 @@ let createRootType (assembly, nameSpace: string, typeName, connectionString, xct
     let providedTypeReuse = if reuseProvidedTypes then WithCache typeCache else NoReuse
     addCreateCommandMethod (connectionString, databaseRootType, commands, customTypes, schemaLookups, xctor, prepare, providedTypeReuse, methodTypes, collectionType)
 
-    databaseRootType           
+    databaseRootType, typeof<obj>
 
 let internal getProviderType (assembly, nameSpace) = 
 
@@ -213,7 +213,7 @@ let internal getProviderType (assembly, nameSpace) =
             ProvidedStaticParameter("MethodTypes", typeof<MethodTypes>, MethodTypes.Sync ||| MethodTypes.Async)
             ProvidedStaticParameter("CollectionType", typeof<CollectionType>, CollectionType.List)
         ],
-        fun typeName args -> typeCache.GetOrAdd (typeName, fun typeName -> createRootType (assembly, nameSpace, typeName, unbox args.[0], unbox args.[1], unbox args.[2], unbox args.[3], unbox args.[4], unbox args.[5])))
+        fun typeName args -> typeCache.GetOrAdd (typeName, fun typeName -> createRootType (assembly, nameSpace, typeName, unbox args.[0], unbox args.[1], unbox args.[2], unbox args.[3], unbox args.[4], unbox args.[5])) |> fst)
 
     providerType.AddXmlDoc """
 <summary>Typed access to PostgreSQL programmable objects, tables and functions.</summary> 

--- a/src/Runtime/DataTable.fs
+++ b/src/Runtime/DataTable.fs
@@ -32,9 +32,12 @@ type CollectionType =
 
 [<EditorBrowsable(EditorBrowsableState.Never); NoEquality; NoComparison>]
 type ResultSetDefinition = {
+    ErasedRowType: System.Type
     ExpectedColumns: DataColumn[] }
 
     with
+        static member Create columns = { ErasedRowType = null; ExpectedColumns = columns }
+
         member x.IsErasableToTuple =
             x.ExpectedColumns.Length > 1 && x.ExpectedColumns.Length < 8
 

--- a/src/Runtime/DataTable.fs
+++ b/src/Runtime/DataTable.fs
@@ -36,8 +36,8 @@ type ResultSetDefinition = {
     ExpectedColumns: DataColumn[] }
 
     with
-        member x.IsErasableToTuple =
-            x.ExpectedColumns.Length > 1 && x.ExpectedColumns.Length < 8
+        member x.CanBeReadWithoutBoxing resultType =
+            (resultType = ResultType.Records || resultType = ResultType.Tuples) && x.ExpectedColumns.Length > 1 && x.ExpectedColumns.Length < 8
 
 type LazySeq<'a> (s: 'a seq, reader: Common.DbDataReader, cmd: NpgsqlCommand) =
     member val Seq = s

--- a/src/Runtime/DataTable.fs
+++ b/src/Runtime/DataTable.fs
@@ -36,8 +36,6 @@ type ResultSetDefinition = {
     ExpectedColumns: DataColumn[] }
 
     with
-        static member Create columns = { ErasedRowType = null; ExpectedColumns = columns }
-
         member x.IsErasableToTuple =
             x.ExpectedColumns.Length > 1 && x.ExpectedColumns.Length < 8
 

--- a/src/Runtime/DataTable.fs
+++ b/src/Runtime/DataTable.fs
@@ -30,10 +30,13 @@ type CollectionType =
     | ResizeArray = 2
     | LazySeq = 3
 
-[<EditorBrowsable(EditorBrowsableState.Never)>]
+[<EditorBrowsable(EditorBrowsableState.Never); NoEquality; NoComparison>]
 type ResultSetDefinition = {
-    SeqItemType: System.Type
     ExpectedColumns: DataColumn[] }
+
+    with
+        member x.IsErasableToTuple =
+            x.ExpectedColumns.Length > 1 && x.ExpectedColumns.Length < 8
 
 type LazySeq<'a> (s: 'a seq, reader: Common.DbDataReader, cmd: NpgsqlCommand) =
     member val Seq = s

--- a/src/Runtime/DataTable.fs
+++ b/src/Runtime/DataTable.fs
@@ -33,11 +33,8 @@ type CollectionType =
 [<EditorBrowsable(EditorBrowsableState.Never); NoEquality; NoComparison>]
 type ResultSetDefinition = {
     ErasedRowType: System.Type
-    ExpectedColumns: DataColumn[] }
-
-    with
-        member x.CanBeReadWithoutBoxing resultType =
-            (resultType = ResultType.Records || resultType = ResultType.Tuples) && x.ExpectedColumns.Length > 1 && x.ExpectedColumns.Length < 8
+    ExpectedColumns: DataColumn[]
+    IsErasedToShortTuple: bool }
 
 type LazySeq<'a> (s: 'a seq, reader: Common.DbDataReader, cmd: NpgsqlCommand) =
     member val Seq = s

--- a/src/Runtime/ISqlCommand.fs
+++ b/src/Runtime/ISqlCommand.fs
@@ -219,7 +219,7 @@ type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> Design
                 
                 let xs =
                     if cfg.ResultSets.[0].CanBeReadWithoutBoxing cfg.ResultType then
-                        NoBoxingMapRowValuesLazy<'TItem> (reader, cfg.ResultSets.[0])
+                        NoBoxingMapRowValuesLazy<'TItem> (reader, cfg.ResultType, cfg.ResultSets.[0])
                     else
                         MapRowValuesLazy<'TItem> (reader, cfg.ResultType, cfg.ResultSets.[0])
 

--- a/src/Runtime/ISqlCommand.fs
+++ b/src/Runtime/ISqlCommand.fs
@@ -20,7 +20,7 @@ type ISqlCommand =
     abstract AsyncExecute: parameters: (string * obj)[] -> obj
     abstract TaskAsyncExecute: parameters: (string * obj)[] -> obj
 
-[<EditorBrowsable(EditorBrowsableState.Never)>]
+[<EditorBrowsable(EditorBrowsableState.Never); NoEquality; NoComparison>]
 type DesignTimeConfig = {
     SqlStatement: string
     Parameters: NpgsqlParameter[]
@@ -28,9 +28,43 @@ type DesignTimeConfig = {
     CollectionType: CollectionType
     SingleRow: bool
     ResultSets: ResultSetDefinition[]
-    UseNetTopologySuite: bool
     Prepare: bool
 }
+    with
+        static member Create (sql, ps, resultType, collection, singleRow, resultSets, prep) = {
+            SqlStatement = sql;
+            Parameters = ps;
+            ResultType = resultType;
+            CollectionType = collection;
+            SingleRow = singleRow;
+            ResultSets = resultSets |> Array.map (fun (r: ResultSetDefinition) ->
+                let t =
+                    match resultType with
+                    | ResultType.Records ->
+                        if r.IsErasableToTuple then
+                            Utils.ToTupleType (r.ExpectedColumns |> Array.sortBy (fun c -> c.ColumnName))
+                        elif r.ExpectedColumns.Length = 1 then
+                            if r.ExpectedColumns.[0].AllowDBNull then
+                                typedefof<_ option>.MakeGenericType r.ExpectedColumns.[0].DataType
+                            else
+                                r.ExpectedColumns.[0].DataType
+                        elif r.ExpectedColumns.Length = 0 then
+                            typeof<int32>
+                        else
+                            typeof<obj[]>
+                    | ResultType.Tuples ->
+                        if r.ExpectedColumns.Length = 1 then
+                            if r.ExpectedColumns.[0].AllowDBNull then
+                                typedefof<_ option>.MakeGenericType r.ExpectedColumns.[0].DataType
+                            else
+                                r.ExpectedColumns.[0].DataType
+                        elif r.ExpectedColumns.Length = 0 then
+                            typeof<int32>
+                        else
+                            Utils.ToTupleType r.ExpectedColumns
+                    | _ -> null
+                { r with ErasedRowType = t });
+           Prepare = prep }
 
 [<EditorBrowsable(EditorBrowsableState.Never)>]
 type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> DesignTimeConfig, connection, commandTimeout) =
@@ -56,12 +90,12 @@ type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> Design
                 | ResultType.Records | ResultType.Tuples ->
                     match cfg.ResultSets with
                     | [| resultSet |] ->
-                        if isNull resultSet.SeqItemType then
+                        if resultSet.ExpectedColumns.Length = 0 then
                             ISqlCommandImplementation.AsyncExecuteNonQuery
                         else
                             typeof<ISqlCommandImplementation>
                                 .GetMethod(nameof ISqlCommandImplementation.AsyncExecuteList, BindingFlags.NonPublic ||| BindingFlags.Static)
-                                .MakeGenericMethod(resultSet.SeqItemType)
+                                .MakeGenericMethod(resultSet.ErasedRowType)
                                 .Invoke(null, [||]) |> unbox
                     | _ ->
                         ISqlCommandImplementation.AsyncExecuteMulti
@@ -82,16 +116,15 @@ type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> Design
         ||| if cfg.ResultType = ResultType.DataTable then CommandBehavior.KeyInfo else CommandBehavior.Default
         ||| match connection with Choice1Of2 _ -> CommandBehavior.CloseConnection | _ -> CommandBehavior.Default
 
-    static let setupConnection (cmd: NpgsqlCommand, connection, useNetTopologySuite) =
+    static let setupConnection (cmd: NpgsqlCommand, connection) =
         match connection with
         | Choice2Of2 (conn, tx) ->
             cmd.Connection <- conn
             cmd.Transaction <- tx
-            Unsafe.uply.Zero ()
-        | Choice1Of2 connectionString -> Unsafe.uply {
+            System.Threading.Tasks.Task.CompletedTask
+        | Choice1Of2 connectionString ->
             cmd.Connection <- new NpgsqlConnection (connectionString)
-            do! cmd.Connection.OpenAsync ()
-            if useNetTopologySuite then cmd.Connection.TypeMapper.UseNetTopologySuite () |> ignore }
+            cmd.Connection.OpenAsync ()
 
     static let mapTask (t: Ply.Ply<_>, executionType) =
         let t = task { return! t }
@@ -144,7 +177,7 @@ type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> Design
 
     static member internal AsyncExecuteDataReaderTask (cfg, cmd, connection, parameters) = Unsafe.uply {
         ISqlCommandImplementation.SetParameters (cmd, parameters)
-        do! setupConnection (cmd, connection, cfg.UseNetTopologySuite)
+        do! setupConnection (cmd, connection)
         let readerBehavior = getReaderBehavior (connection, cfg)
 
         if cfg.Prepare then
@@ -244,16 +277,16 @@ type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> Design
         
         let func =
             let mutable x = Unchecked.defaultof<_>
-            if executeSingleCache.TryGetValue (resultSetDefinition.SeqItemType, &x) then
+            if executeSingleCache.TryGetValue (resultSetDefinition.ErasedRowType, &x) then
                 x
             else
                 let func = 
                     typeof<ISqlCommandImplementation>
                         .GetMethod(nameof ISqlCommandImplementation.ExecuteSingle, BindingFlags.NonPublic ||| BindingFlags.Static)
-                        .MakeGenericMethod(resultSetDefinition.SeqItemType)
+                        .MakeGenericMethod(resultSetDefinition.ErasedRowType)
                         .Invoke(null, [||]) :?> Func<_, _, _, Ply.Ply<obj>>
 
-                executeSingleCache.[resultSetDefinition.SeqItemType] <- func
+                executeSingleCache.[resultSetDefinition.ErasedRowType] <- func
                 func
 
         func.Invoke (cursor, resultSetDefinition, cfg)
@@ -282,7 +315,7 @@ type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> Design
     static member internal AsyncExecuteNonQuery (cfg, cmd, connection, parameters, executionType) = 
         let t = Unsafe.uply {
             ISqlCommandImplementation.SetParameters (cmd, parameters)
-            do! setupConnection (cmd, connection, cfg.UseNetTopologySuite)
+            do! setupConnection (cmd, connection)
             let readerBehavior = getReaderBehavior (connection, cfg)
             use _ = if readerBehavior.HasFlag CommandBehavior.CloseConnection then cmd.Connection else null
 

--- a/src/Runtime/ISqlCommand.fs
+++ b/src/Runtime/ISqlCommand.fs
@@ -218,7 +218,7 @@ type ISqlCommandImplementation (commandNameHash: int, cfgBuilder: unit -> Design
                 let! reader = ISqlCommandImplementation.AsyncExecuteDataReaderTask (cfg, cmd, connection, parameters)
                 
                 let xs =
-                    if cfg.ResultSets.[0].CanBeReadWithoutBoxing cfg.ResultType then
+                    if cfg.ResultSets.[0].IsErasedToShortTuple then
                         NoBoxingMapRowValuesLazy<'TItem> (reader, cfg.ResultType, cfg.ResultSets.[0])
                     else
                         MapRowValuesLazy<'TItem> (reader, cfg.ResultType, cfg.ResultSets.[0])

--- a/tests/NpgsqlConnectionTests.fs
+++ b/tests/NpgsqlConnectionTests.fs
@@ -4,6 +4,10 @@ open System
 open Xunit
 open FSharp.Data.Npgsql
 open System.Reflection
+open type Npgsql.NpgsqlNetTopologySuiteExtensions
+open NetTopologySuite.Geometries
+
+Npgsql.NpgsqlConnection.GlobalTypeMapper.UseNetTopologySuite () |> ignore
 
 let isStatementPrepared (connection: Npgsql.NpgsqlConnection) =
     let pool = typeof<Npgsql.NpgsqlConnection>.GetProperty("Pool", BindingFlags.NonPublic ||| BindingFlags.Instance).GetValue(connection)

--- a/tests/NpgsqlConnectionTests.fs
+++ b/tests/NpgsqlConnectionTests.fs
@@ -1065,15 +1065,24 @@ let ``NetTopology.Geometry roundtrip works`` () =
 [<Fact>]
 let ``NetTopology.Geometry roundtrip works record`` () =
     let input = Geometry.DefaultFactory.CreatePoint (Coordinate (55., 0.))
-    use cmd = DvdRentalWithTypeReuse.CreateCommand<"select @p::geometry g, 0 blah">(connectionString)
+    use cmd = DvdRentalWithTypeReuse.CreateCommand<"select @p::geometry g, 0 blah, null::geometry gg">(connectionString)
     let res = cmd.Execute(input).Head.g.Value
     
     Assert.Equal (input.Coordinate.X, res.Coordinate.X)
 
 [<Fact>]
+let ``NetTopology.Geometry roundtrip works record single row`` () =
+    let input = Geometry.DefaultFactory.CreatePoint (Coordinate (55., 0.))
+    use cmd = DvdRentalWithTypeReuse.CreateCommand<"select @p::geometry g, 0 blah, null::geometry gg", SingleRow = true>(connectionString)
+    let res = cmd.Execute(input).Value
+    
+    Assert.Equal (input.Coordinate.X, res.g.Value.Coordinate.X)
+    Assert.Equal (None, res.gg)
+
+[<Fact>]
 let ``NetTopology.Geometry roundtrip works tuple`` () =
     let input = Geometry.DefaultFactory.CreatePoint (Coordinate (55., 0.))
-    use cmd = DvdRentalWithTypeReuse.CreateCommand<"select @p::geometry g, 0 blah", ResultType = ResultType.Tuples>(connectionString)
+    use cmd = DvdRentalWithTypeReuse.CreateCommand<"select @p::geometry g, 0 blah, null::geometry gg", ResultType = ResultType.Tuples>(connectionString)
     let res = cmd.Execute(input).Head |> fst |> Option.get
     
     Assert.Equal (input.Coordinate.X, res.Coordinate.X)

--- a/tests/NpgsqlConnectionTests.fs
+++ b/tests/NpgsqlConnectionTests.fs
@@ -1083,6 +1083,6 @@ let ``NetTopology.Geometry roundtrip works record single row`` () =
 let ``NetTopology.Geometry roundtrip works tuple`` () =
     let input = Geometry.DefaultFactory.CreatePoint (Coordinate (55., 0.))
     use cmd = DvdRentalWithTypeReuse.CreateCommand<"select @p::geometry g, 0 blah, null::geometry gg", ResultType = ResultType.Tuples>(connectionString)
-    let res = cmd.Execute(input).Head |> fst |> Option.get
+    let res, _, _ = cmd.Execute(input).Head
     
-    Assert.Equal (input.Coordinate.X, res.Coordinate.X)
+    Assert.Equal (input.Coordinate.X, res.Value.Coordinate.X)

--- a/tests/Program.fs
+++ b/tests/Program.fs
@@ -6,6 +6,8 @@ open Npgsql
 
 [<EntryPoint>]
 let main _ =
+    NpgsqlConnection.GlobalTypeMapper.UseNetTopologySuite () |> ignore
+
     use cmd = DvdRental.CreateCommand<"begin;delete from film where film_id = -5000;end;">(connectionString)
     printfn "%A" (cmd.Execute())
   


### PR DESCRIPTION
Selects with 2-7 columns are erased into tuples rather than `obj[]` and values are loaded from Npgsql with no boxing.